### PR TITLE
Extracted chia specific logic into the infrastructure layer and kept application layer blockchain agnostic

### DIFF
--- a/src/application/interfaces/IBlockChainService.ts
+++ b/src/application/interfaces/IBlockChainService.ts
@@ -1,7 +1,34 @@
 import { Block } from "../types/Block";
+import type { Coin, Peer, UnspentCoinsResponse } from '@dignetwork/datalayer-driver';
 
 
 export interface IBlockchainService {
   getCurrentBlockchainHeight(): Promise<number>;
   getBlockchainBlockByHeight(height: number): Promise<Block>;
+  // Key and address methods
+  masterSecretKeyFromSeed(seed: Buffer): Buffer;
+  secretKeyToPublicKey(secretKey: Buffer): Buffer;
+  masterPublicKeyToWalletSyntheticKey(publicKey: Buffer): Buffer;
+  masterSecretKeyToWalletSyntheticSecretKey(secretKey: Buffer): Buffer;
+  masterPublicKeyToFirstPuzzleHash(publicKey: Buffer): Buffer;
+  puzzleHashToAddress(puzzleHash: Buffer, prefix: string): string;
+  signMessage(message: Buffer, privateKey: Buffer): Buffer;
+  // Coin selection
+  getCoinId(coin: Coin): Buffer;
+  selectCoins(coins: Coin[], amount: bigint): Coin[];
+  // ColdWallet/WalletService methods
+  getPuzzleHash(address: string): Buffer;
+  verifyKeySignature(signature: Buffer, publicKey: Buffer, message: Buffer): boolean;
+  listUnspentCoins(
+    peer: Peer,
+    puzzleHash: Buffer,
+    previousHeight: number,
+    previousHeaderHash: Buffer
+  ): Promise<UnspentCoinsResponse>;
+  isCoinSpendable(
+    peer: Peer,
+    coinId: Buffer,
+    lastHeight: number,
+    headerHash: Buffer
+  ): Promise<boolean>;
 }

--- a/src/infrastructure/BlockchainServices/ChiaBlockchainService.ts
+++ b/src/infrastructure/BlockchainServices/ChiaBlockchainService.ts
@@ -1,12 +1,87 @@
-
 import { IBlockchainService } from "../../application/interfaces/IBlockChainService";
 import { Block } from "../../application/types/Block";
+import {
+  masterSecretKeyToWalletSyntheticSecretKey,
+  masterPublicKeyToWalletSyntheticKey,
+  masterPublicKeyToFirstPuzzleHash,
+  secretKeyToPublicKey,
+  puzzleHashToAddress,
+  signMessage,
+  getCoinId,
+  selectCoins,
+  addressToPuzzleHash,
+  verifySignedMessage,
+} from '@dignetwork/datalayer-driver';
+import type { Coin, Peer, UnspentCoinsResponse } from '@dignetwork/datalayer-driver';
+import { PrivateKey } from 'chia-bls';
 
 export class ChiaBlockchainService implements IBlockchainService {
   async getCurrentBlockchainHeight(): Promise<number> {
     return 0;
   }
+
   async getBlockchainBlockByHeight(height: number): Promise<Block> {
     return { hash: Buffer.from('abc', 'hex'), blockHeight: height };
+  }
+
+  masterSecretKeyFromSeed(seed: Buffer): Buffer {
+    return Buffer.from(PrivateKey.fromSeed(seed).toHex(), 'hex');
+  }
+
+  secretKeyToPublicKey(secretKey: Buffer): Buffer {
+    return secretKeyToPublicKey(secretKey);
+  }
+
+  masterPublicKeyToWalletSyntheticKey(publicKey: Buffer): Buffer {
+    return masterPublicKeyToWalletSyntheticKey(publicKey);
+  }
+
+  masterSecretKeyToWalletSyntheticSecretKey(secretKey: Buffer): Buffer {
+    return masterSecretKeyToWalletSyntheticSecretKey(secretKey);
+  }
+  
+  masterPublicKeyToFirstPuzzleHash(publicKey: Buffer): Buffer {
+    return masterPublicKeyToFirstPuzzleHash(publicKey);
+  }
+
+  puzzleHashToAddress(puzzleHash: Buffer, prefix: string): string {
+    return puzzleHashToAddress(puzzleHash, prefix);
+  }
+
+  signMessage(message: Buffer, privateKey: Buffer): Buffer {
+    return signMessage(message, privateKey);
+  }
+
+  getCoinId(coin: Coin): Buffer {
+    return getCoinId(coin);
+  }
+
+  selectCoins(coins: Coin[], amount: bigint): Coin[] {
+    return selectCoins(coins, amount);
+  }
+
+  getPuzzleHash(address: string): Buffer {
+    return addressToPuzzleHash(address);
+  }
+  verifyKeySignature(signature: Buffer, publicKey: Buffer, message: Buffer): boolean {
+    return verifySignedMessage(signature, publicKey, message);
+  }
+
+  async listUnspentCoins(
+    peer: Peer,
+    puzzleHash: Buffer,
+    previousHeight: number,
+    previousHeaderHash: Buffer
+  ): Promise<UnspentCoinsResponse> {
+    return await peer.getAllUnspentCoins(puzzleHash, previousHeight, previousHeaderHash);
+  }
+  
+  async isCoinSpendable(
+    peer: Peer,
+    coinId: Buffer,
+    lastHeight: number,
+    headerHash: Buffer
+  ): Promise<boolean> {
+    return !(await peer.isCoinSpent(coinId, lastHeight, headerHash));
   }
 }

--- a/src/infrastructure/BlockchainServices/TestBlockchainService.ts
+++ b/src/infrastructure/BlockchainServices/TestBlockchainService.ts
@@ -1,7 +1,8 @@
-
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { IBlockchainService } from "../../application/interfaces/IBlockChainService";
 import { Block } from "../../application/types/Block";
 import Database from 'better-sqlite3';
+import type { Coin, Peer, UnspentCoinsResponse } from '@dignetwork/datalayer-driver';
 
 export class TestBlockchainService implements IBlockchainService {
   private db: Database.Database;
@@ -23,5 +24,40 @@ export class TestBlockchainService implements IBlockchainService {
       hash: row.hash,
       blockHeight: row.blockHeight,
     };
+  }
+
+  masterSecretKeyFromSeed(seed: Buffer): Buffer { return Buffer.alloc(32, 1); }
+  secretKeyToPublicKey(secretKey: Buffer): Buffer { return Buffer.alloc(32, 2); }
+  masterPublicKeyToWalletSyntheticKey(publicKey: Buffer): Buffer { return Buffer.alloc(32, 3); }
+  masterSecretKeyToWalletSyntheticSecretKey(secretKey: Buffer): Buffer { return Buffer.alloc(32, 4); }
+  masterPublicKeyToFirstPuzzleHash(publicKey: Buffer): Buffer { return Buffer.alloc(32, 5); }
+  puzzleHashToAddress(puzzleHash: Buffer, prefix: string): string { return prefix + puzzleHash.toString('hex'); }
+  signMessage(message: Buffer, privateKey: Buffer): Buffer { return Buffer.from('deadbeef', 'hex'); }
+  getCoinId(coin: Coin): Buffer { return Buffer.from('cafebabe', 'hex'); }
+  selectCoins(coins: Coin[], amount: bigint): Coin[] { return coins.slice(0, 1); }
+
+  // New methods for ColdWallet/WalletService
+  getPuzzleHash(address: string): Buffer {
+    return Buffer.from(address, 'utf-8'); // Dummy
+  }
+  verifyKeySignature(signature: Buffer, publicKey: Buffer, message: Buffer): boolean {
+    return true; // Dummy
+  }
+  async listUnspentCoins(
+    peer: Peer,
+    puzzleHash: Buffer,
+    previousHeight: number,
+    previousHeaderHash: Buffer
+  ): Promise<UnspentCoinsResponse> {
+    // Dummy: return a fake response
+    return { coins: [], lastHeight: 0, lastHeaderHash: Buffer.alloc(32) };
+  }
+  async isCoinSpendable(
+    peer: Peer,
+    coinId: Buffer,
+    lastHeight: number,
+    headerHash: Buffer
+  ): Promise<boolean> {
+    return true; // Dummy
   }
 }


### PR DESCRIPTION
* remove references to datalayer driver from the application layer as it is chia-bound and moved them to the infrastructure layer
* updated the interface of the blockchain service to accomodate for the new needed methods and moved implementation from the application layer into the chiablockchainservice
* kept some references to datalayer driver in the application for the types (such as Peer, Coin) as do don't have DTOs for them for now, but shuld be removed later